### PR TITLE
Fix typo in FILTER attribute.

### DIFF
--- a/lib/frigidaire.js
+++ b/lib/frigidaire.js
@@ -60,7 +60,7 @@ function Frigidaire(options) {
   this.getBusy = false; // global lock for get requests.  Slow them down as simultanious requests are tripping over
 
   // attributes
-  this.FLITER=7000;
+  this.FILTER=7000;
   // 7001 - sleep mode
   this.MODE=7002;
   this.SETPOINT=7003;


### PR DESCRIPTION
I was reviewing the code and came across (what I assume to be) a typo in the FILTER attribute. It doesn't appear to be used in `demo.js`, so I suspect there will be little impact.