### PR TITLE
temperatures are returned as array's 2nd element

### DIFF
--- a/lib/frigidaire.js
+++ b/lib/frigidaire.js
@@ -752,7 +752,7 @@
          }
  
          if (attr.haclCode === '0430' || attr.haclCode === '0432') {
-             var value = attr.containers[0].numberValue;
+             var value = attr.containers[1].numberValue;
          }
          else {
              var value = attr.numberValue;


### PR DESCRIPTION
temperatures weren't displaying correct in homekit, saw that the temp value is now returned as the second object in the array, not the first.